### PR TITLE
Changed package.json

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,7 +20,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.48.0",
         "react-hot-toast": "^2.4.1",
-        "react-leaflet": "^5.0.0",
+        "react-leaflet": "^4.2.1",
         "socket.io-client": "^4.7.4",
         "tailwind-merge": "^2.6.0"
       },
@@ -489,14 +489,14 @@
       }
     },
     "node_modules/@react-leaflet/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
       "license": "Hippocratic-2.1",
       "peerDependencies": {
         "leaflet": "^1.9.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4462,17 +4462,17 @@
       "dev": true
     },
     "node_modules/react-leaflet": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
-      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
       "license": "Hippocratic-2.1",
       "dependencies": {
-        "@react-leaflet/core": "^3.0.0"
+        "@react-leaflet/core": "^2.1.0"
       },
       "peerDependencies": {
         "leaflet": "^1.9.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,11 +17,10 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.294.0",
     "next": "14.0.0",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^18",    "react-dom": "^18",
     "react-hook-form": "^7.48.0",
     "react-hot-toast": "^2.4.1",
-    "react-leaflet": "^5.0.0",
+    "react-leaflet": "^4.2.1",
     "socket.io-client": "^4.7.4",
     "tailwind-merge": "^2.6.0"
   },


### PR DESCRIPTION
This pull request downgrades the `react-leaflet` package from version `5.0.0` to `4.2.1` and updates its associated dependencies to ensure compatibility with React 18. The changes primarily affect the `client/package-lock.json` and `client/package.json` files.

### Dependency Updates:

* [`client/package-lock.json`](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL23-R23): Downgraded `react-leaflet` to version `4.2.1` and updated its dependency `@react-leaflet/core` to version `2.1.0`. Adjusted `peerDependencies` of `@react-leaflet/core` to require React 18 instead of React 19. [[1]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL23-R23) [[2]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL492-R499) [[3]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL4465-R4475)
* [`client/package.json`](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL20-R23): Updated `react-leaflet` to version `4.2.1` to align with the downgraded version in `package-lock.json`.